### PR TITLE
Update refrence for @StateObject to be a @Backport.StateObject

### DIFF
--- a/Shared/Backport Demos/StateObjectDemo.swift
+++ b/Shared/Backport Demos/StateObjectDemo.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftUIBackports
 
 struct StateObjectDemo: View {
     var body: some View {
@@ -34,7 +35,7 @@ private final class Counter: ObservableObject {
 }
 
 private struct ChildView: View {
-    @StateObject private var owned = Counter()
+    @Backport.StateObject private var owned = Counter()
     @ObservedObject private var observed = Counter()
 
     var body: some View {


### PR DESCRIPTION
The original StateObjectDemo referenced a `@StateObject`, but I believe the demo was meant to show the capabilities of `@Backport.StateObject`.  I've updated this reference to a `@Backport.StateObject`.

As an aside, Xcode appears to have a bug where it is not catching this illegal reference to Apple's `@StateObject` despite the project targeting iOS 13.  This causes a crash in the demo when run on a iOS 13 device.  Here is a reference to a StackOverflow post that references this issue:
https://stackoverflow.com/questions/70414615/i-am-able-to-use-stateobject-in-ios-13-is-that-a-bug-or-is-it-real